### PR TITLE
feat(analytics): add GTM dataLayer tracking to blog section

### DIFF
--- a/src/components/article/blog/BlogListing.astro
+++ b/src/components/article/blog/BlogListing.astro
@@ -34,11 +34,14 @@ const content =
 ---
 
 <li
-  class="w-80 border-[0.25px] border-grey rounded-3xl hover:border-transparent hover:linaro-gradient-border cursor-pointer bg-background f"
+  class="w-80 border-[0.25px] border-grey rounded-3xl hover:border-transparent hover:linaro-gradient-border cursor-pointer bg-background flex flex-col justify-between"
+  data-blog-card
+  data-blog-title={blog.title}
+  data-blog-tags={JSON.stringify(tags.map(t => t.data.name))}
 >
   <a
     href={`/${collection === "blogs" ? "blog" : collection}/${id}`}
-    class="w-full px-4 pt-8 pb-12 inline-block flex flex-col justify-between h-full"
+    class="w-full px-4 pt-8 pb-12 inline-block flex flex-col basis-full"
   >
     <div class="basis-full">
       <CloudinaryImg
@@ -69,14 +72,57 @@ const content =
       </p>
       <p>{content}</p>
     </div>
-    <ul class="flex flex-wrap gap-x-4 gap-y-8 justify-self-end mt-8">
-      {
-        tags.map((tag) => (
-          <li>
-            <button class="linaro-gradient-button">{tag.data.name}</button>
-          </li>
-        ))
-      }
-    </ul>
   </a>
+  <ul class="flex flex-wrap gap-x-4 gap-y-8 px-4 py-8 justify-self-end">
+    {
+      tags.map((tag) => {
+        const tagSlug = tag.id.replace(/\.mdx?$/, "");
+        return (
+          <li>
+            <a
+              href={`/blog?tags=${tagSlug}`}
+              class="linaro-gradient-button"
+              data-blog-tag={tag.data.name}
+            >{tag.data.name}</a>
+          </li>
+        );
+      })
+    }
+  </ul>
 </li>
+
+<script>
+  document.querySelectorAll('[data-blog-card]').forEach((card) => {
+    const el = card as HTMLElement;
+    const cardTitle = el.dataset.blogTitle ?? '';
+    const cardTags = JSON.parse(el.dataset.blogTags ?? '[]') as string[];
+
+    el.querySelector('a:first-of-type')?.addEventListener('click', () => {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        'event': 'blog_card_click',
+        'navigation': { 'type': 'Card' },
+        'blog': {
+          'title': cardTitle,
+          'tag_count': cardTags.length,
+          'tags': cardTags
+        }
+      });
+    });
+
+    el.querySelectorAll('[data-blog-tag]').forEach((tagEl) => {
+      tagEl.addEventListener('click', () => {
+        const tagName = (tagEl as HTMLElement).dataset.blogTag ?? '';
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({
+          'event': 'blog_tag_click',
+          'navigation': {
+            'tag': tagName,
+            'type': 'Tag',
+            'action': 'Select'
+          }
+        });
+      });
+    });
+  });
+</script>

--- a/src/components/article/blog/BlogResults.tsx
+++ b/src/components/article/blog/BlogResults.tsx
@@ -33,6 +33,21 @@ const BlogResult = ({
       <a
         href={article()?.url}
         class="w-full px-4 pt-8 pb-12 inline-block basis-full"
+        onClick={() => {
+          const tagNames = (article()?.filters.tags ?? []).map(
+            (tag: string) => tags?.find(({ id }) => id === tag)?.data.name ?? tag
+          );
+          (window as any).dataLayer = (window as any).dataLayer || [];
+          (window as any).dataLayer.push({
+            'event': 'blog_card_click',
+            'navigation': { 'type': 'Card' },
+            'blog': {
+              'title': article()?.meta.title ?? '',
+              'tag_count': tagNames.length,
+              'tags': tagNames
+            }
+          });
+        }}
       >
         <img
           src={isSsr ? "/placeholder.jpg" : article()?.meta.image}
@@ -62,7 +77,22 @@ const BlogResult = ({
       <ul class="flex flex-wrap gap-x-4 gap-y-8 px-4 py-8 justify-self-end">
         {article()?.filters.tags.map((tag: string) => (
           <li>
-            <a href={`/blog?tags=${tag}`}>
+            <a
+              href={`/blog?tags=${tag}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                const tagName = tags?.find(({ id }) => id === tag)?.data.name ?? tag;
+                (window as any).dataLayer = (window as any).dataLayer || [];
+                (window as any).dataLayer.push({
+                  'event': 'blog_tag_click',
+                  'navigation': {
+                    'tag': tagName,
+                    'type': 'Tag',
+                    'action': 'Select'
+                  }
+                });
+              }}
+            >
               <div class="linaro-gradient-button">
                 {tags?.find(({ id }) => id === tag)?.data.name}
               </div>

--- a/src/components/article/blog/BlogSearch.tsx
+++ b/src/components/article/blog/BlogSearch.tsx
@@ -121,6 +121,9 @@ const BlogSearch = ({
 
       const currentTags = search().filters.tags;
 
+      const clickedTagName = tags.find(t => t.id === clickedTag)?.data.name ?? clickedTag;
+      const action = currentTags.includes(clickedTag) ? 'Deselect' : 'Select';
+
       let newTags;
       if (currentTags.includes(clickedTag)) {
         newTags = [...currentTags.filter((tag) => tag !== clickedTag)];
@@ -137,6 +140,28 @@ const BlogSearch = ({
       };
 
       updateSearch(newSearch);
+
+      // blog_tag_click — fires for any tag toggle in the filter section
+      (window as any).dataLayer = (window as any).dataLayer || [];
+      (window as any).dataLayer.push({
+        'event': 'blog_tag_click',
+        'navigation': {
+          'tag': clickedTagName,
+          'type': 'Tag',
+          'action': action
+        }
+      });
+
+      // blog_filter_applied — only fires from the Tags filter section on the blog homepage
+      const newTagNames = newTags.map(id => tags.find(t => t.id === id)?.data.name ?? id);
+      (window as any).dataLayer.push({
+        'event': 'blog_filter_applied',
+        'blog': {
+          'title': 'Blog Homepage',
+          'tag_count': newTags.length,
+          'tags': newTagNames
+        }
+      });
     };
 
   const [results] = createResource(search, fetchResults);

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -148,6 +148,17 @@ if (related && related.length > 0) {
   </aside>
 </BaseLayout>
 
+<script is:inline define:vars={{ dlTitle: title, dlTags: tags.map(t => t.data.name) }}>
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    'blog': {
+      'title': dlTitle,
+      'tag_count': dlTags.length,
+      'tags': dlTags
+    }
+  });
+</script>
+
 <style define:vars={{ backgroundUrl: `url(${optimizedBackground.src})` }}>
   /* Ensure we can see global theme variables */
   @reference "../styles/global.css";

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -30,6 +30,23 @@ const isSsr = import.meta.env.DEV || !import.meta.env.IS_PUBLIC;
     <BlogSearch client:only="solid-js" tags={tags} type="blogs" isSsr={isSsr} />
   </main>
 </BaseLayout>
+<script is:inline define:vars={{ allTagsJson: tags.map(t => ({ id: t.id, name: t.data.name })) }}>
+  window.dataLayer = window.dataLayer || [];
+  const url = new URL(window.location.href);
+  const activeTagIds = url.searchParams.get('tags')?.split(',').filter(Boolean) ?? [];
+  const activeTagNames = activeTagIds.map(id => {
+    const found = allTagsJson.find(t => t.id === id);
+    return found ? found.name : id;
+  });
+  window.dataLayer.push({
+    'blog': {
+      'title': 'Blog Homepage',
+      'tag_count': activeTagNames.length,
+      'tags': activeTagNames
+    }
+  });
+</script>
+
 <style define:vars={{ backgroundUrl: `url(${optimizedBackground.src})` }}>
   .hero-background-image {
     background-image: var(--backgroundUrl);


### PR DESCRIPTION
Adds blog_tag_click, blog_filter_applied, and blog_card_click dataLayer events on tag clicks, filter changes, and card clicks. Also pushes blog metadata on page load for both the blog homepage and individual post pages.