### PR TITLE
Ungate GTM - load unconditionally

### DIFF
--- a/src/components/head/BaseHead.astro
+++ b/src/components/head/BaseHead.astro
@@ -107,7 +107,7 @@ const social_image = getCldOgImageUrl({
   <meta charset="utf-8" />
   <Cookies />
 
-  <script type="text/plain" data-category="analytics_cookies">
+  <script is:inline>
     (function (w, d, s, l, i) {
       w[l] = w[l] || [];
       w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });


### PR DESCRIPTION
Although https://linaro.atlassian.net/browse/WEBDEV-2935 is for the CoreCollective website, the problem also exists on the Linaro website. This change allows the GTM script to be loaded unconditionally.
